### PR TITLE
Move editing packages to app dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,14 +34,14 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
   bloc: ^8.1.0
   flutter_bloc: ^8.1.0
   video_editor: ^3.0.0
   image_picker: ^1.0.4
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## Summary
- move `bloc`, `flutter_bloc`, `video_editor`, and `image_picker` from dev_dependencies to dependencies
- verify EditingControls callbacks align with `video_editor` API

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f59263d48326a4945f2f848d7f7e