### PR TITLE
Add video editing dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,15 +34,15 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  equatable: ^2.0.5
   bloc: ^8.1.0
   flutter_bloc: ^8.1.0
   video_editor: ^3.0.0
   image_picker: ^1.0.4
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your


### PR DESCRIPTION
## Summary
- add equatable, bloc, flutter_bloc, video_editor, and image_picker as runtime dependencies
- remove the packages from dev_dependencies

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `apt-get update` *(fails: 403  Forbidden)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f58862508326b9f9f41c47af7543