### PR TITLE
Fix video trim calculations and video preview

### DIFF
--- a/lib/bloc/video_editor_bloc.dart
+++ b/lib/bloc/video_editor_bloc.dart
@@ -51,11 +51,15 @@ class VideoEditorBloc extends Bloc<VideoEditorEvent, VideoEditorState> {
     emit(VideoEditing());
 
     try {
-      // Set posisi trim di controller video_editor (BUKAN VideoPlayerController)
-      currentState.controller.updateTrim(event.start, event.end);
+      // Set posisi trim di controller video_editor menggunakan rasio (0 - 1)
+      final controller = currentState.controller;
+      final duration = controller.videoDuration.inMilliseconds.toDouble();
+      final start = event.start.inMilliseconds / duration;
+      final end = event.end.inMilliseconds / duration;
+      controller.updateTrim(start, end);
 
       // Balik ke state loaded (controller sudah ter-update)
-      emit(VideoLoaded(currentState.controller));
+      emit(VideoLoaded(controller));
     } catch (e) {
       emit(VideoError('Failed to trim video: $e'));
     }

--- a/lib/widgets/editing_controls.dart
+++ b/lib/widgets/editing_controls.dart
@@ -24,8 +24,6 @@ class EditingControls extends StatelessWidget {
             child: TrimSlider(
               controller: controller,
               height: 48,
-              onChangeStart: (s) {},
-              onChangeEnd: (s) {},
             ),
           ),
 

--- a/lib/widgets/video_preview.dart
+++ b/lib/widgets/video_preview.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:video_editor/video_editor.dart';
+import 'package:video_player/video_player.dart';
 
 class VideoPreview extends StatelessWidget {
   final VideoEditorController controller;
@@ -15,7 +16,7 @@ class VideoPreview extends StatelessWidget {
           aspectRatio: controller.video.value.aspectRatio == 0
               ? 16 / 9
               : controller.video.value.aspectRatio,
-          child: const VideoViewer(), // dari package video_editor
+          child: VideoPlayer(controller.video),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   flutter_bloc: ^8.1.0
   video_editor: ^3.0.0
   image_picker: ^1.0.4
+  video_player: ^2.8.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Convert trim durations to ratios before calling controller
- Remove unsupported TrimSlider callbacks
- Replace missing VideoViewer with VideoPlayer and add dependency

## Testing
- `flutter analyze` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a5f982df2c8326bb711942962bcfd6