### PR TITLE
Specify VideoEditorController durations

### DIFF
--- a/lib/bloc/video_editor_bloc.dart
+++ b/lib/bloc/video_editor_bloc.dart
@@ -27,9 +27,9 @@ class VideoEditorBloc extends Bloc<VideoEditorEvent, VideoEditorState> {
 
       final controller = VideoEditorController.file(
         File(event.path),
-        // opsional: atur batas durasi trim
-        // minDuration: const Duration(seconds: 1),
-        // maxDuration: const Duration(seconds: 30),
+        // set explicit trim range to satisfy controller assertions
+        minDuration: const Duration(seconds: 1),
+        maxDuration: const Duration(minutes: 1),
       );
 
       await controller.initialize();


### PR DESCRIPTION
## Summary
- ensure VideoEditorController receives explicit min and max durations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ffe6aa048326a256ccd6aa01c952