### PR TITLE
Add multi-clip video editor with transitions and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # simple_video_editing
 
-A new Flutter project.
+A simple Flutter video editor that can merge multiple clips with basic fade
+transitions and export the final video using FFmpeg.
+
+## Features
+- Import multiple videos from the device
+- Set a fade or hard cut transition between clips
+- Export the combined video to an mp4 file
+
+This project is a starting point for experimenting with simple video editing
+workflows in Flutter.
 
 ## Getting Started
-
-This project is a starting point for a Flutter application.
 
 A few resources to get you started if this is your first Flutter project:
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'bloc/video_editor_bloc.dart';
-import 'pages/video_editor_page.dart';
+import 'pages/multi_video_editor_page.dart';
 
 void main() {
-  runApp(
-    BlocProvider(
-      create: (_) => VideoEditorBloc(),
-      child: const MyApp(),
-    ),
-  );
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
@@ -27,7 +20,7 @@ class MyApp extends StatelessWidget {
         scaffoldBackgroundColor: Colors.black,
         useMaterial3: true,
       ),
-      home: const VideoEditorPage(),
+      home: const MultiVideoEditorPage(),
     );
   }
 }

--- a/lib/models/video_clip.dart
+++ b/lib/models/video_clip.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+
+enum TransitionType { none, fade }
+
+class VideoClip {
+  final String path;
+  final Duration duration;
+  TransitionType transition;
+
+  VideoClip({
+    required this.path,
+    required this.duration,
+    this.transition = TransitionType.fade,
+  });
+}

--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -1,0 +1,169 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:ffmpeg_kit_flutter_full_gpl/ffmpeg_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+import '../models/video_clip.dart';
+
+class MultiVideoEditorPage extends StatefulWidget {
+  const MultiVideoEditorPage({super.key});
+
+  @override
+  State<MultiVideoEditorPage> createState() => _MultiVideoEditorPageState();
+}
+
+class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
+  final List<VideoClip> _clips = [];
+  bool _isExporting = false;
+
+  Future<void> _addVideos() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.video,
+      allowMultiple: true,
+    );
+    if (result != null) {
+      for (final file in result.files) {
+        final controller = VideoPlayerController.file(File(file.path!));
+        await controller.initialize();
+        _clips.add(
+          VideoClip(
+            path: file.path!,
+            duration: controller.value.duration,
+          ),
+        );
+        await controller.dispose();
+      }
+      setState(() {});
+    }
+  }
+
+  Future<void> _export() async {
+    if (_clips.isEmpty || _isExporting) return;
+    setState(() => _isExporting = true);
+
+    final output = '${Directory.systemTemp.path}/output.mp4';
+    final inputs = _clips.map((c) => "-i '${c.path}'").join(' ');
+
+    String filter = '';
+    String currentV = '[0:v]';
+    String currentA = '[0:a]';
+    double currentDur = _clips.first.duration.inSeconds.toDouble();
+
+    for (var i = 1; i < _clips.length; i++) {
+      final prev = _clips[i - 1];
+      if (prev.transition == TransitionType.fade) {
+        filter +=
+            '$currentV$currentA[$i:v][$i:a]xfade=transition=fade:duration=1:offset=${currentDur - 1}[v$i][a$i];';
+        currentV = '[v$i]';
+        currentA = '[a$i]';
+        currentDur += _clips[i].duration.inSeconds.toDouble() - 1;
+      } else {
+        filter +=
+            '$currentV$currentA[$i:v][$i:a]concat=n=2:v=1:a=1[v$i][a$i];';
+        currentV = '[v$i]';
+        currentA = '[a$i]';
+        currentDur += _clips[i].duration.inSeconds.toDouble();
+      }
+    }
+
+    final cmd = _clips.length == 1
+        ? "$inputs -c copy $output"
+        : "$inputs -filter_complex \"$filter\" -map $currentV -map $currentA $output";
+
+    await FFmpegKit.execute(cmd);
+    setState(() => _isExporting = false);
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Export complete: $output')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Video Combiner'),
+        actions: [
+          IconButton(
+            tooltip: 'Export',
+            icon: const Icon(Icons.save_alt),
+            onPressed: _export,
+          ),
+        ],
+      ),
+      body: _clips.isEmpty
+          ? Center(
+              child: ElevatedButton.icon(
+                onPressed: _addVideos,
+                icon: const Icon(Icons.video_library),
+                label: const Text('Add Videos'),
+              ),
+            )
+          : Column(
+              children: [
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: _clips.length,
+                    itemBuilder: (context, index) {
+                      final clip = _clips[index];
+                      return ListTile(
+                        leading: Text('Clip ${index + 1}'),
+                        title: Text(clip.path.split('/').last),
+                        trailing: DropdownButton<TransitionType>(
+                          value: clip.transition,
+                          items: TransitionType.values
+                              .map(
+                                (t) => DropdownMenuItem(
+                                  value: t,
+                                  child: Text(t.name),
+                                ),
+                              )
+                              .toList(),
+                          onChanged: (value) {
+                            if (value == null) return;
+                            setState(() => clip.transition = value);
+                          },
+                        ),
+                        onLongPress: () {
+                          setState(() => _clips.removeAt(index));
+                        },
+                      );
+                    },
+                  ),
+                ),
+                SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        ElevatedButton.icon(
+                          onPressed: _addVideos,
+                          icon: const Icon(Icons.add),
+                          label: const Text('Add Videos'),
+                        ),
+                        ElevatedButton.icon(
+                          onPressed: _export,
+                          icon: _isExporting
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Icon(Icons.save_alt),
+                          label: const Text('Export'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
   video_editor: ^3.0.0
   image_picker: ^1.0.4
   video_player: ^2.8.1
+  file_picker: ^5.2.10
+  ffmpeg_kit_flutter_full_gpl: ^4.5.1
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,10 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_video_editing/main.dart';
 
 void main() {
-  testWidgets('shows import button on start', (WidgetTester tester) async {
+  testWidgets('shows add videos button on start', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    expect(find.text('Import Video'), findsOneWidget);
+    expect(find.text('Add Videos'), findsOneWidget);
     expect(find.byIcon(Icons.video_library), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add page to combine multiple videos with fade or hard-cut transitions
- allow exporting merged video using FFmpeg
- update app entrypoint, tests, and docs

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c298ca7c83268a63612df1aa7df0