### PR TITLE
chore: bump Kotlin plugin version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.application") version "8.5.2"
-    id("org.jetbrains.kotlin.android") version "1.9.24"
+    id("org.jetbrains.kotlin.android") version "2.1.0"
     // HARUS setelah Android & Kotlin
     id("dev.flutter.flutter-gradle-plugin")
 }


### PR DESCRIPTION
## Summary
- update Kotlin Android plugin to 2.1.0

## Testing
- `flutter clean && flutter pub get` *(fails: command not found)*
- `gradle assembleDebug` *(fails: /workspace/simple-video-editing/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68a7359c2388832699f588b235b47928