### PR TITLE
Add Flutter embedding dependency to Android app

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -32,4 +32,8 @@ android {
     }
 }
 
+dependencies {
+    implementation("io.flutter:flutter_embedding_debug:ea121f8859e4b13e47a8f845e4586164519588bc")
+}
+
 flutter { source = "../.." }


### PR DESCRIPTION
## Summary
- add dependencies block to android/app build script
- include flutter_embedding_debug dependency matching the SDK revision

## Testing
- `gradle -p android app:assembleDebug` *(fails: android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68a738f6e87883268f498d99c8e1ac55