### PR TITLE
chore(android): bump Android plugin to 8.6.0

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "8.5.2"
+    id("com.android.application") version "8.6.0"
     id("org.jetbrains.kotlin.android") version "2.1.0"
     // HARUS setelah Android & Kotlin
     id("dev.flutter.flutter-gradle-plugin")


### PR DESCRIPTION
## Summary
- bump Android Gradle plugin to version 8.6.0

## Testing
- `gradle help` *(fails: `/workspace/simple-video-editing/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_68a738f40cc48326b449b4a453d47fa0