### PR TITLE
Align FFmpegKit version with plugin

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -8,11 +8,13 @@ subprojects {
     // setiap subproject build ke ../build/<nama-subproject>
     layout.buildDirectory.set(buildRoot.dir(name))
 
-    // Paksa versi FFmpegKit ke 6.0-1
+    // Ensure FFmpegKit matches the version bundled with ffmpeg_kit_flutter_new
     configurations.all {
         resolutionStrategy.eachDependency {
             if (requested.group == "com.arthenica" && requested.name.startsWith("ffmpeg-kit-")) {
-                useVersion("6.0-1") // ganti ke "6.0" kalau 6.0-1 masih 404
+                // Plugin ffmpeg_kit_flutter_new 3.2.0 currently ships with FFmpegKit 6.0
+                // Update this pin when upgrading the plugin to avoid using outdated binaries
+                useVersion("6.0")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Align FFmpegKit dependency override with ffmpeg_kit_flutter_new 3.2.0
- Remove outdated comment about fallback versions and clarify upgrade instructions

## Testing
- `gradle -q help` *(fails: /workspace/simple-video-editing/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68ac2973a0e08326a3b2ea8e562c25fa