### PR TITLE
feat: add preview and timeline UI

### DIFF
--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -17,6 +17,8 @@ class MultiVideoEditorPage extends StatefulWidget {
 class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
   final List<VideoClip> _clips = [];
   bool _isExporting = false;
+  VideoPlayerController? _previewController;
+  int _selectedIndex = 0;
 
   Future<void> _addVideos() async {
     final result = await FilePicker.platform.pickFiles(
@@ -35,8 +37,28 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
         );
         await controller.dispose();
       }
+      _selectedIndex = 0;
+      await _initPreview();
       setState(() {});
     }
+  }
+
+  Future<void> _initPreview() async {
+    if (_clips.isEmpty) {
+      await _previewController?.dispose();
+      _previewController = null;
+      return;
+    }
+    await _previewController?.dispose();
+    final clip = _clips[_selectedIndex];
+    _previewController = VideoPlayerController.file(File(clip.path));
+    await _previewController!.initialize();
+    setState(() {});
+  }
+
+  Future<void> _onSelectClip(int index) async {
+    _selectedIndex = index;
+    await _initPreview();
   }
 
   Future<void> _export() async {
@@ -85,14 +107,7 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Video Combiner'),
-        actions: [
-          IconButton(
-            tooltip: 'Export',
-            icon: const Icon(Icons.save_alt),
-            onPressed: _export,
-          ),
-        ],
+        title: const Text('Video Editor'),
       ),
       body: _clips.isEmpty
           ? Center(
@@ -105,31 +120,115 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
           : Column(
               children: [
                 Expanded(
-                  child: ListView.builder(
+                  child: Center(
+                    child: _previewController == null ||
+                            !_previewController!.value.isInitialized
+                        ? const Text('No clip selected')
+                        : AspectRatio(
+                            aspectRatio:
+                                _previewController!.value.aspectRatio,
+                            child: Stack(
+                              alignment: Alignment.bottomCenter,
+                              children: [
+                                VideoPlayer(_previewController!),
+                                VideoProgressIndicator(
+                                  _previewController!,
+                                  allowScrubbing: true,
+                                ),
+                                Positioned(
+                                  bottom: 8,
+                                  right: 8,
+                                  child: IconButton(
+                                    icon: Icon(
+                                      _previewController!
+                                              .value.isPlaying
+                                          ? Icons.pause
+                                          : Icons.play_arrow,
+                                    ),
+                                    onPressed: () {
+                                      setState(() {
+                                        if (_previewController!
+                                            .value.isPlaying) {
+                                          _previewController!.pause();
+                                        } else {
+                                          _previewController!.play();
+                                        }
+                                      });
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                  ),
+                ),
+                SizedBox(
+                  height: 120,
+                  child: ReorderableListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    onReorder: (oldIndex, newIndex) {
+                      setState(() {
+                        if (newIndex > oldIndex) newIndex--;
+                        final item = _clips.removeAt(oldIndex);
+                        _clips.insert(newIndex, item);
+                        if (_selectedIndex == oldIndex) {
+                          _selectedIndex = newIndex;
+                          _initPreview();
+                        } else if (oldIndex < _selectedIndex &&
+                            newIndex > _selectedIndex) {
+                          _selectedIndex--;
+                        } else if (oldIndex > _selectedIndex &&
+                            newIndex <= _selectedIndex) {
+                          _selectedIndex++;
+                        }
+                      });
+                    },
                     itemCount: _clips.length,
                     itemBuilder: (context, index) {
                       final clip = _clips[index];
-                      return ListTile(
-                        leading: Text('Clip ${index + 1}'),
-                        title: Text(clip.path.split('/').last),
-                        trailing: DropdownButton<TransitionType>(
-                          value: clip.transition,
-                          items: TransitionType.values
-                              .map(
-                                (t) => DropdownMenuItem(
-                                  value: t,
-                                  child: Text(t.name),
-                                ),
-                              )
-                              .toList(),
-                          onChanged: (value) {
-                            if (value == null) return;
-                            setState(() => clip.transition = value);
-                          },
-                        ),
+                      return GestureDetector(
+                        key: ValueKey(clip.path),
+                        onTap: () => _onSelectClip(index),
                         onLongPress: () {
-                          setState(() => _clips.removeAt(index));
+                          setState(() {
+                            _clips.removeAt(index);
+                            if (_clips.isEmpty) {
+                              _selectedIndex = 0;
+                              _initPreview();
+                            } else if (_selectedIndex >= _clips.length) {
+                              _selectedIndex = _clips.length - 1;
+                              _initPreview();
+                            }
+                          });
                         },
+                        child: Container(
+                          width: 120,
+                          margin: const EdgeInsets.all(8),
+                          color: _selectedIndex == index
+                              ? Colors.teal
+                              : Colors.grey[800],
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text('Clip ${index + 1}'),
+                              DropdownButton<TransitionType>(
+                                value: clip.transition,
+                                items: TransitionType.values
+                                    .map(
+                                      (t) => DropdownMenuItem(
+                                        value: t,
+                                        child: Text(t.name),
+                                      ),
+                                    )
+                                    .toList(),
+                                onChanged: (value) {
+                                  if (value == null) return;
+                                  setState(() => clip.transition = value);
+                                },
+                              ),
+                            ],
+                          ),
+                        ),
                       );
                     },
                   ),
@@ -165,5 +264,11 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
               ],
             ),
     );
+  }
+
+  @override
+  void dispose() {
+    _previewController?.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- add video preview player with play/pause
- introduce horizontal timeline to reorder clips and adjust transitions

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d72cb648326b554ea643f618869