### PR TITLE
Add thumbnail timeline with drag reorder

### DIFF
--- a/lib/models/video_clip.dart
+++ b/lib/models/video_clip.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart';
 
 enum TransitionType { none, fade }
@@ -5,11 +7,13 @@ enum TransitionType { none, fade }
 class VideoClip {
   final String path;
   final Duration duration;
+  final Uint8List? thumbnail;
   TransitionType transition;
 
   VideoClip({
     required this.path,
     required this.duration,
+    this.thumbnail,
     this.transition = TransitionType.fade,
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   video_player: ^2.8.1
   file_picker: ^10.3.2
   ffmpeg_kit_flutter_new: ^3.2.0
+  video_thumbnail: ^0.5.3
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace ReorderableListView with custom horizontal timeline
- generate clip thumbnails and durations for timeline
- enable drag-and-drop reordering and double tap removal

## Testing
- `dart format lib/pages/multi_video_editor_page.dart lib/models/video_clip.dart pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad144587a883268f4c35aa22cc3a85