### PR TITLE
Add interactive overlays for video preview

### DIFF
--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -19,6 +19,14 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
   bool _isExporting = false;
   VideoPlayerController? _previewController;
   int _selectedIndex = 0;
+  double _previewScale = 1.0;
+
+  String _format(Duration d) {
+    String two(int n) => n.toString().padLeft(2, '0');
+    final minutes = two(d.inMinutes.remainder(60));
+    final seconds = two(d.inSeconds.remainder(60));
+    return '$minutes:$seconds';
+  }
 
   Future<void> _addVideos() async {
     final result = await FilePicker.platform.pickFiles(
@@ -124,41 +132,116 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
                     child: _previewController == null ||
                             !_previewController!.value.isInitialized
                         ? const Text('No clip selected')
-                        : AspectRatio(
-                            aspectRatio:
-                                _previewController!.value.aspectRatio,
-                            child: Stack(
-                              alignment: Alignment.bottomCenter,
-                              children: [
-                                VideoPlayer(_previewController!),
-                                VideoProgressIndicator(
-                                  _previewController!,
-                                  allowScrubbing: true,
-                                ),
-                                Positioned(
-                                  bottom: 8,
-                                  right: 8,
-                                  child: IconButton(
-                                    icon: Icon(
-                                      _previewController!
-                                              .value.isPlaying
-                                          ? Icons.pause
-                                          : Icons.play_arrow,
-                                    ),
-                                    onPressed: () {
+                        : LayoutBuilder(
+                            builder: (context, constraints) {
+                              final controller = _previewController!;
+                              return ValueListenableBuilder<VideoPlayerValue>(
+                                valueListenable: controller,
+                                builder: (context, value, child) {
+                                  final duration = value.duration;
+                                  final position = value.position;
+                                  final width = constraints.maxWidth;
+
+                                  return GestureDetector(
+                                    onTap: () {
+                                      value.isPlaying
+                                          ? controller.pause()
+                                          : controller.play();
+                                    },
+                                    onHorizontalDragUpdate: (details) {
+                                      final relative = details.delta.dx / width;
+                                      final newPosition = position.inMilliseconds +
+                                          duration.inMilliseconds * relative;
+                                      final clamped = newPosition.clamp(
+                                        0,
+                                        duration.inMilliseconds.toDouble(),
+                                      );
+                                      controller.seekTo(
+                                        Duration(milliseconds: clamped.toInt()),
+                                      );
+                                    },
+                                    onScaleUpdate: (details) {
                                       setState(() {
-                                        if (_previewController!
-                                            .value.isPlaying) {
-                                          _previewController!.pause();
-                                        } else {
-                                          _previewController!.play();
-                                        }
+                                        _previewScale =
+                                            details.scale.clamp(1.0, 5.0);
                                       });
                                     },
-                                  ),
-                                ),
-                              ],
-                            ),
+                                    child: Stack(
+                                      children: [
+                                        Center(
+                                          child: AspectRatio(
+                                            aspectRatio: value.aspectRatio,
+                                            child: Transform.scale(
+                                              scale: _previewScale,
+                                              child: VideoPlayer(controller),
+                                            ),
+                                          ),
+                                        ),
+                                        Positioned(
+                                          bottom: 8,
+                                          left: 8,
+                                          child: Icon(
+                                            value.isPlaying
+                                                ? Icons.pause_circle
+                                                : Icons.play_circle,
+                                            size: 48,
+                                            color: Colors.white70,
+                                          ),
+                                        ),
+                                        Positioned(
+                                          bottom: 0,
+                                          left: 0,
+                                          right: 0,
+                                          child: Column(
+                                            children: [
+                                              Slider(
+                                                value: position
+                                                    .inMilliseconds
+                                                    .toDouble(),
+                                                min: 0,
+                                                max: duration.inMilliseconds
+                                                    .toDouble(),
+                                                onChanged: (v) => controller
+                                                    .seekTo(Duration(
+                                                        milliseconds:
+                                                            v.toInt())),
+                                              ),
+                                              Padding(
+                                                padding: const EdgeInsets.only(
+                                                    bottom: 4),
+                                                child: Text(
+                                                  '${_format(position)} / ${_format(duration)}',
+                                                  style: const TextStyle(
+                                                      color: Colors.white),
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                        Positioned(
+                                          bottom: 28,
+                                          left: 0,
+                                          child: Container(
+                                            width: 4,
+                                            height: 20,
+                                            color: Colors.white,
+                                          ),
+                                        ),
+                                        Positioned(
+                                          bottom: 28,
+                                          right: 0,
+                                          child: Container(
+                                            width: 4,
+                                            height: 20,
+                                            color: Colors.white,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  );
+                                },
+                              );
+                            },
                           ),
                   ),
                 ),

--- a/lib/widgets/video_preview.dart
+++ b/lib/widgets/video_preview.dart
@@ -2,23 +2,142 @@ import 'package:flutter/material.dart';
 import 'package:video_editor/video_editor.dart';
 import 'package:video_player/video_player.dart';
 
-class VideoPreview extends StatelessWidget {
+class VideoPreview extends StatefulWidget {
   final VideoEditorController controller;
   const VideoPreview({super.key, required this.controller});
 
   @override
+  State<VideoPreview> createState() => _VideoPreviewState();
+}
+
+class _VideoPreviewState extends State<VideoPreview> {
+  double _scale = 1.0;
+
+  String _format(Duration d) {
+    String two(int n) => n.toString().padLeft(2, '0');
+    final minutes = two(d.inMinutes.remainder(60));
+    final seconds = two(d.inSeconds.remainder(60));
+    return "$minutes:$seconds";
+  }
+
+  @override
   Widget build(BuildContext context) {
-    // VideoEditor menyediakan VideoViewer untuk playback
-    return Container(
-      color: Colors.black,
-      child: Center(
-        child: AspectRatio(
-          aspectRatio: controller.video.value.aspectRatio == 0
-              ? 16 / 9
-              : controller.video.value.aspectRatio,
-          child: VideoPlayer(controller.video),
-        ),
-      ),
+    final videoController = widget.controller.video;
+
+    return ValueListenableBuilder<VideoPlayerValue>(
+      valueListenable: videoController,
+      builder: (context, value, child) {
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            final width = constraints.maxWidth;
+            final duration = value.duration;
+            final position = value.position;
+
+            final showHandles = widget.controller.startTrim > Duration.zero ||
+                widget.controller.endTrim < widget.controller.videoDuration;
+
+            final startPos = widget.controller.startTrim.inMilliseconds /
+                widget.controller.videoDuration.inMilliseconds *
+                width;
+            final endPos = widget.controller.endTrim.inMilliseconds /
+                widget.controller.videoDuration.inMilliseconds *
+                width;
+
+            return GestureDetector(
+              onTap: () {
+                value.isPlaying
+                    ? videoController.pause()
+                    : videoController.play();
+              },
+              onHorizontalDragUpdate: (details) {
+                final relative = details.delta.dx / width;
+                final newPosition = position.inMilliseconds +
+                    duration.inMilliseconds * relative;
+                final clamped = newPosition.clamp(
+                  0,
+                  duration.inMilliseconds.toDouble(),
+                );
+                videoController.seekTo(
+                  Duration(milliseconds: clamped.toInt()),
+                );
+              },
+              onScaleUpdate: (details) {
+                setState(() {
+                  _scale = details.scale.clamp(1.0, 5.0);
+                });
+              },
+              child: Stack(
+                children: [
+                  Center(
+                    child: AspectRatio(
+                      aspectRatio:
+                          value.aspectRatio == 0 ? 16 / 9 : value.aspectRatio,
+                      child: Transform.scale(
+                        scale: _scale,
+                        child: VideoPlayer(videoController),
+                      ),
+                    ),
+                  ),
+                  Center(
+                    child: Icon(
+                      value.isPlaying
+                          ? Icons.pause_circle
+                          : Icons.play_circle,
+                      color: Colors.white70,
+                      size: 64,
+                    ),
+                  ),
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: Column(
+                      children: [
+                        Slider(
+                          value: position.inMilliseconds.toDouble(),
+                          min: 0,
+                          max: duration.inMilliseconds.toDouble(),
+                          onChanged: (v) => videoController.seekTo(
+                            Duration(milliseconds: v.toInt()),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Text(
+                            '${_format(position)} / ${_format(duration)}',
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (showHandles) ...[
+                    Positioned(
+                      bottom: 28,
+                      left: startPos - 2,
+                      child: Container(
+                        width: 4,
+                        height: 20,
+                        color: Colors.white,
+                      ),
+                    ),
+                    Positioned(
+                      bottom: 28,
+                      left: endPos - 2,
+                      child: Container(
+                        width: 4,
+                        height: 20,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            );
+          },
+        );
+      },
     );
   }
 }
+


### PR DESCRIPTION
## Summary
- wrap video player in stack with play/pause control, timecode and seek bar
- add gesture-based seeking, zooming, and trim handles for previews

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ad14478444832688514bc104cc07be