### PR TITLE
Add transition selection and export support

### DIFF
--- a/lib/models/video_clip.dart
+++ b/lib/models/video_clip.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 
-enum TransitionType { none, fade }
+enum TransitionType { none, fade, slide }
 
 class VideoClip {
   final String path;
@@ -14,6 +14,6 @@ class VideoClip {
     required this.path,
     required this.duration,
     this.thumbnail,
-    this.transition = TransitionType.fade,
+    this.transition = TransitionType.none,
   });
 }

--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -8,6 +8,7 @@ import 'package:video_player/video_player.dart';
 import 'package:video_thumbnail/video_thumbnail.dart';
 
 import '../models/video_clip.dart';
+import '../widgets/transition_selector.dart';
 
 class MultiVideoEditorPage extends StatefulWidget {
   const MultiVideoEditorPage({super.key});
@@ -187,9 +188,11 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
 
     for (var i = 1; i < _clips.length; i++) {
       final prev = _clips[i - 1];
-      if (prev.transition == TransitionType.fade) {
+      if (prev.transition != TransitionType.none) {
+        final transition =
+            prev.transition == TransitionType.fade ? 'fade' : 'slideleft';
         filter +=
-            '$currentV$currentA[$i:v][$i:a]xfade=transition=fade:duration=1:offset=${currentDur - 1}[v$i][a$i];';
+            '$currentV$currentA[$i:v][$i:a]xfade=transition=$transition:duration=1:offset=${currentDur - 1}[v$i][a$i];';
         currentV = '[v$i]';
         currentA = '[a$i]';
         currentDur += _clips[i].duration.inSeconds.toDouble() - 1;
@@ -278,10 +281,18 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
     setState(() {});
   }
 
-  void _openTransitionSettings() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Transition settings coming soon')),
+  Future<void> _openTransitionSettings() async {
+    if (_clips.isEmpty) return;
+    final selected = await showModalBottomSheet<TransitionType>(
+      context: context,
+      builder: (context) =>
+          TransitionSelector(initial: _clips[_selectedIndex].transition),
     );
+    if (selected != null) {
+      setState(() {
+        _clips[_selectedIndex].transition = selected;
+      });
+    }
   }
 
   @override

--- a/lib/widgets/transition_selector.dart
+++ b/lib/widgets/transition_selector.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../models/video_clip.dart';
+
+class TransitionSelector extends StatelessWidget {
+  final TransitionType initial;
+  const TransitionSelector({super.key, required this.initial});
+
+  String _labelFor(TransitionType t) {
+    switch (t) {
+      case TransitionType.none:
+        return 'None';
+      case TransitionType.fade:
+        return 'Fade';
+      case TransitionType.slide:
+        return 'Slide';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: TransitionType.values
+          .map(
+            (t) => ListTile(
+              title: Text(_labelFor(t)),
+              trailing: t == initial ? const Icon(Icons.check) : null,
+              onTap: () => Navigator.pop(context, t),
+            ),
+          )
+          .toList(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add slide option to transition type and default to none
- introduce `TransitionSelector` bottom sheet to choose clip transitions
- include chosen transitions when exporting with FFmpeg

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2127a0308326afe15b83da3695c8