### PR TITLE
Use VideoPreview for clip editing

### DIFF
--- a/lib/models/video_clip.dart
+++ b/lib/models/video_clip.dart
@@ -14,6 +14,8 @@ class VideoClip {
   final ClipType type;
   final String? text;
   TransitionType transition;
+  Duration start;
+  Duration end;
 
   VideoClip({
     this.path,
@@ -23,5 +25,8 @@ class VideoClip {
     this.type = ClipType.video,
     this.text,
     this.transition = TransitionType.none,
-  });
+    Duration? start,
+    Duration? end,
+  })  : start = start ?? Duration.zero,
+        end = end ?? duration;
 }


### PR DESCRIPTION
## Summary
- track individual clip trim ranges in `VideoClip`
- use `VideoPreview` powered by `VideoEditorController` for zoomable preview
- expose `TrimSlider` and keep controller in sync with selected clip

## Testing
- `dart format lib/pages/multi_video_editor_page.dart lib/models/video_clip.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad25c43da483269426b783bf625182