### PR TITLE
Insert videos after first clip and drop thumbnail generation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   video_player: ^2.8.1
   file_picker: ^10.3.2
   ffmpeg_kit_flutter_new: ^3.2.0
-  video_thumbnail: ^0.5.3
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- remove thumbnail generation when adding or splitting clips
- insert newly added videos directly after the first clip
- allow dragging clips without long-press
- drop video_thumbnail dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3d4b1a708326bae7d793c1cda742