### PR TITLE
Add editor toolbar and timeline view

### DIFF
--- a/lib/widgets/editor_toolbar.dart
+++ b/lib/widgets/editor_toolbar.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class EditorToolbar extends StatelessWidget {
+  final VoidCallback? onEdit;
+  final VoidCallback? onAudio;
+  final VoidCallback? onText;
+  final VoidCallback? onEffect;
+  final VoidCallback? onOverlay;
+  final VoidCallback? onCaption;
+
+  const EditorToolbar({
+    super.key,
+    this.onEdit,
+    this.onAudio,
+    this.onText,
+    this.onEffect,
+    this.onOverlay,
+    this.onCaption,
+  });
+
+  Widget _buildItem(IconData icon, String label, VoidCallback? onTap) {
+    return Expanded(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: Colors.white),
+              const SizedBox(height: 4),
+              Text(
+                label,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.black87,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          _buildItem(Icons.edit, 'Edit', onEdit),
+          _buildItem(Icons.audiotrack, 'Audio', onAudio),
+          _buildItem(Icons.text_fields, 'Teks', onText),
+          _buildItem(Icons.movie_filter, 'Efek', onEffect),
+          _buildItem(Icons.layers, 'Overlay', onOverlay),
+          _buildItem(Icons.closed_caption, 'Keterangan', onCaption),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement reusable editor toolbar with edit, audio, text, effect, overlay and caption actions
- enhance multi video editor page with stacked timeline, playhead overlay, and new toolbar
- move export action to the app bar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad668de4708326afadf2c1a6f846e6