### PR TITLE
Simplify timeline to single track

### DIFF
--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -397,40 +397,24 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
                   ),
                 ),
                 SizedBox(
-                  height: 80.0 * _tracks.length,
-                  child: Stack(
-                    children: [
-                      Column(
-                        children: [
-                          for (var t = 0; t < _tracks.length; t++)
-                            SizedBox(
-                              height: 80,
-                              child: ListView.builder(
-                                scrollDirection: Axis.horizontal,
-                                itemCount: _tracks[t].length + 1,
-                                itemBuilder: (context, index) {
-                                  if (index == _tracks[t].length) {
-                                    return _buildDragTarget(
-                                      t,
-                                      index,
-                                      const SizedBox(width: 116),
-                                    );
-                                  }
-                                  return _buildDragTarget(
-                                    t,
-                                    index,
-                                    _buildDraggableClip(t, index),
-                                  );
-                                },
-                              ),
-                            ),
-                        ],
-                      ),
-                      Align(
-                        alignment: Alignment.center,
-                        child: Container(width: 2, color: Colors.white70),
-                      ),
-                    ],
+                  height: 80,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: _tracks.last.length + 1,
+                    itemBuilder: (context, index) {
+                      if (index == _tracks.last.length) {
+                        return _buildDragTarget(
+                          _tracks.length - 1,
+                          index,
+                          const SizedBox(width: 116),
+                        );
+                      }
+                      return _buildDragTarget(
+                        _tracks.length - 1,
+                        index,
+                        _buildDraggableClip(_tracks.length - 1, index),
+                      );
+                    },
                   ),
                 ),
                 if (_previewController != null &&


### PR DESCRIPTION
## Summary
- Replace multi-track Stack timeline with single ListView targeting the last track
- Ensure drag-and-drop operations focus on final track using `_tracks.length - 1`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6b11a58c8326bc17666c06276a2f