### PR TITLE
feat: use VideoTrack as only timeline

### DIFF
--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -41,19 +41,17 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
     return null;
   }
 
-  Future<void> _addVideos({int? insertIndex}) async {
+  Future<void> _addVideos() async {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.video,
       allowMultiple: true,
     );
     if (result != null) {
-      var index = insertIndex ?? (_clips.isEmpty ? 0 : _selectedIndex + 1);
       for (final file in result.files) {
         final controller = VideoPlayerController.file(File(file.path!));
         await controller.initialize();
         final wave = await _generateWaveform(file.path!);
-        _clips.insert(
-          index,
+        _clips.add(
           VideoClip(
             path: file.path!,
             duration: controller.value.duration,
@@ -61,10 +59,9 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
             type: ClipType.video,
           ),
         );
-        index++;
         await controller.dispose();
       }
-      _selectedIndex = index - 1;
+      _selectedIndex = _clips.length - 1;
       await _initPreview();
       setState(() {});
     }
@@ -341,7 +338,7 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
                   selectedIndex: _selectedIndex,
                   onSelect: _onSelectClip,
                   onReorder: _reorderClips,
-                  onAppend: () => _addVideos(insertIndex: _clips.length),
+                  onAppend: _addVideos,
                   onRemove: _removeClip,
                 ),
                 SafeArea(

--- a/lib/widgets/video_preview.dart
+++ b/lib/widgets/video_preview.dart
@@ -13,13 +13,6 @@ class VideoPreview extends StatefulWidget {
 class _VideoPreviewState extends State<VideoPreview> {
   double _scale = 1.0;
 
-  String _format(Duration d) {
-    String two(int n) => n.toString().padLeft(2, '0');
-    final minutes = two(d.inMinutes.remainder(60));
-    final seconds = two(d.inSeconds.remainder(60));
-    return "$minutes:$seconds";
-  }
-
   @override
   Widget build(BuildContext context) {
     final videoController = widget.controller.video;
@@ -87,33 +80,9 @@ class _VideoPreviewState extends State<VideoPreview> {
                       size: 64,
                     ),
                   ),
-                  Positioned(
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
-                    child: Column(
-                      children: [
-                        Slider(
-                          value: position.inMilliseconds.toDouble(),
-                          min: 0,
-                          max: duration.inMilliseconds.toDouble(),
-                          onChanged: (v) => videoController.seekTo(
-                            Duration(milliseconds: v.toInt()),
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 4),
-                          child: Text(
-                            '${_format(position)} / ${_format(duration)}',
-                            style: const TextStyle(color: Colors.white),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
                   if (showHandles) ...[
                     Positioned(
-                      bottom: 28,
+                      bottom: 0,
                       left: startPos - 2,
                       child: Container(
                         width: 4,
@@ -122,7 +91,7 @@ class _VideoPreviewState extends State<VideoPreview> {
                       ),
                     ),
                     Positioned(
-                      bottom: 28,
+                      bottom: 0,
                       left: endPos - 2,
                       child: Container(
                         width: 4,


### PR DESCRIPTION
## Summary
- append new videos at end of clip list
- drop progress slider so VideoTrack is the only timeline

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ade0d05b4c8326974bf324f6545ee5