### PR TITLE
feat: add timeline trim handles

### DIFF
--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -171,6 +171,20 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
     });
   }
 
+  void _trimClip(int index, Duration newStart, Duration newEnd) {
+    final clip = _clips[index];
+    setState(() {
+      clip.start = newStart;
+      clip.end = newEnd;
+    });
+    if (index == _selectedIndex && _previewController != null) {
+      _previewController!.updateTrim(
+        newStart.inMilliseconds / clip.duration.inMilliseconds,
+        newEnd.inMilliseconds / clip.duration.inMilliseconds,
+      );
+    }
+  }
+
   Future<void> _export() async {
     final clips = _clips;
     if (clips.isEmpty || _isExporting) return;
@@ -340,6 +354,7 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
                   onReorder: _reorderClips,
                   onAppend: _addVideos,
                   onRemove: _removeClip,
+                  onTrim: _trimClip,
                 ),
                 SafeArea(
                   top: false,

--- a/lib/widgets/video_track.dart
+++ b/lib/widgets/video_track.dart
@@ -10,6 +10,7 @@ class VideoTrack extends StatelessWidget {
   final void Function(int from, int to)? onReorder;
   final VoidCallback? onAppend;
   final ValueChanged<int>? onRemove;
+  final void Function(int index, Duration newStart, Duration newEnd)? onTrim;
   final double height;
 
   const VideoTrack({
@@ -20,12 +21,13 @@ class VideoTrack extends StatelessWidget {
     this.onReorder,
     this.onAppend,
     this.onRemove,
+    this.onTrim,
     this.height = 80,
   });
 
   Widget _buildDraggableClip(BuildContext context, int index) {
     final clip = clips[index];
-    return Draggable<Map<String, int>>(
+    return LongPressDraggable<Map<String, int>>(
       data: {'index': index},
       dragAnchorStrategy: pointerDragAnchorStrategy,
       feedback: Material(
@@ -39,6 +41,7 @@ class VideoTrack extends StatelessWidget {
         child: TimelineClip(
           clip: clip,
           selected: selectedIndex == index,
+          onTrim: (s, e) => onTrim?.call(index, s, e),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add draggable trim handles to selected timeline clips
- propagate trim changes via VideoTrack to editor state and preview
- show trimmed duration

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade0d19bb88326a924d9246dfe57cb