### PR TITLE
Add clear all clips option

### DIFF
--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -286,6 +286,33 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
     setState(() {});
   }
 
+  Future<void> _clearAllClips() async {
+    if (!_hasAnyClip) return;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Clear all clips?'),
+        content: const Text('This will remove all clips from the timeline.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      _clips.clear();
+      _selectedIndex = 0;
+      await _initPreview();
+      setState(() {});
+    }
+  }
+
   Future<void> _openTransitionSettings() async {
     if (_clips.isEmpty) return;
     final clip = _clips[_selectedIndex];
@@ -316,6 +343,11 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
           IconButton(
             icon: const Icon(Icons.video_library),
             onPressed: () => _addVideos(),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_forever),
+            tooltip: 'Clear all',
+            onPressed: _hasAnyClip ? _clearAllClips : null,
           ),
           IconButton(
             icon: _isExporting

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,5 +9,9 @@ void main() {
 
     expect(find.text('Add Videos'), findsOneWidget);
     expect(find.byIcon(Icons.video_library), findsOneWidget);
+    expect(find.byIcon(Icons.delete_forever), findsOneWidget);
+    final deleteButton =
+        tester.widget<IconButton>(find.byIcon(Icons.delete_forever));
+    expect(deleteButton.onPressed, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- add confirmation dialog to remove all clips from timeline
- expose clear-all button in editor app bar
- test for presence and disabled state of the clear-all button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af25b703588326b78ae150927b3562