### PR TITLE
Refactor editor UI toward CapCut style

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,11 +13,17 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Simple Video Editor',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.teal,
-          brightness: Brightness.dark,
+        brightness: Brightness.dark,
+        colorScheme: const ColorScheme.dark(
+          primary: Colors.white,
+          secondary: Color(0xFF22C55E),
         ),
-        scaffoldBackgroundColor: Colors.black,
+        scaffoldBackgroundColor: const Color(0xFF0E0E0F),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.black,
+          foregroundColor: Colors.white,
+        ),
+        iconTheme: const IconThemeData(color: Colors.white),
         useMaterial3: true,
       ),
       home: const MultiVideoEditorPage(),

--- a/lib/pages/multi_video_editor_page.dart
+++ b/lib/pages/multi_video_editor_page.dart
@@ -12,6 +12,7 @@ import '../widgets/transition_selector.dart';
 import '../widgets/video_preview.dart';
 import '../widgets/editor_toolbar.dart';
 import '../widgets/video_track.dart';
+import '../widgets/editor_app_bar.dart';
 
 class MultiVideoEditorPage extends StatefulWidget {
   const MultiVideoEditorPage({super.key});
@@ -286,6 +287,33 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
     setState(() {});
   }
 
+  Future<void> _clearAllClips() async {
+    if (!_hasAnyClip) return;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Clear all clips?'),
+        content: const Text('This will remove all clips from the timeline.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      _clips.clear();
+      _selectedIndex = 0;
+      await _initPreview();
+      setState(() {});
+    }
+  }
+
   Future<void> _openTransitionSettings() async {
     if (_clips.isEmpty) return;
     final clip = _clips[_selectedIndex];
@@ -310,28 +338,20 @@ class _MultiVideoEditorPageState extends State<MultiVideoEditorPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Video Editor'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.video_library),
-            onPressed: () => _addVideos(),
-          ),
-          IconButton(
-            icon: _isExporting
-                ? const SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.save_alt),
-            onPressed: _isExporting ? null : _export,
-          ),
-        ],
+      appBar: EditorAppBar(
+        onAdd: _addVideos,
+        onExport: _export,
+        onClear: _clearAllClips,
+        hasClips: _hasAnyClip,
+        isExporting: _isExporting,
       ),
       body: !_hasAnyClip
           ? Center(
-              child: ElevatedButton.icon(
+              child: OutlinedButton.icon(
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.white,
+                  side: const BorderSide(color: Colors.white),
+                ),
                 onPressed: () => _addVideos(),
                 icon: const Icon(Icons.video_library),
                 label: const Text('Add Videos'),

--- a/lib/widgets/editor_app_bar.dart
+++ b/lib/widgets/editor_app_bar.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class EditorAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final VoidCallback onAdd;
+  final VoidCallback onExport;
+  final VoidCallback onClear;
+  final bool hasClips;
+  final bool isExporting;
+
+  const EditorAppBar({
+    super.key,
+    required this.onAdd,
+    required this.onExport,
+    required this.onClear,
+    required this.hasClips,
+    required this.isExporting,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: Colors.black,
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: () => Navigator.of(context).maybePop(),
+      ),
+      title: const Text('Edit'),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.video_library),
+          onPressed: onAdd,
+        ),
+        IconButton(
+          icon: const Icon(Icons.delete_forever),
+          tooltip: 'Clear all',
+          onPressed: hasClips ? onClear : null,
+        ),
+        IconButton(
+          icon: isExporting
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.save_alt),
+          onPressed: isExporting ? null : onExport,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/widgets/editor_toolbar.dart
+++ b/lib/widgets/editor_toolbar.dart
@@ -43,7 +43,10 @@ class EditorToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Colors.black87,
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        border: Border(top: BorderSide(color: Colors.white24)),
+      ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: [

--- a/lib/widgets/timeline_clip.dart
+++ b/lib/widgets/timeline_clip.dart
@@ -28,8 +28,8 @@ class TimelineClip extends StatelessWidget {
       margin: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         border: Border.all(
-          color: selected ? Colors.teal : Colors.transparent,
-          width: 3,
+          color: selected ? Colors.white : Colors.transparent,
+          width: 2,
         ),
         borderRadius: BorderRadius.circular(8),
       ),
@@ -76,7 +76,7 @@ class TimelineClip extends StatelessWidget {
                 },
                 child: Container(
                   width: 8,
-                  color: Colors.black38,
+                  color: Colors.white24,
                 ),
               ),
             ),
@@ -103,7 +103,7 @@ class TimelineClip extends StatelessWidget {
                 },
                 child: Container(
                   width: 8,
-                  color: Colors.black38,
+                  color: Colors.white24,
                 ),
               ),
             ),
@@ -115,7 +115,7 @@ class TimelineClip extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
               child: Text(
                 _formatDuration(clip.end - clip.start),
-                style: const TextStyle(fontSize: 12),
+                style: const TextStyle(fontSize: 12, color: Colors.white),
               ),
             ),
           ),

--- a/lib/widgets/video_track.dart
+++ b/lib/widgets/video_track.dart
@@ -57,8 +57,9 @@ class VideoTrack extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
+    return Container(
       height: height,
+      color: Colors.grey.shade900,
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
         itemCount: clips.length + 1,
@@ -73,9 +74,9 @@ class VideoTrack extends StatelessWidget {
                   margin: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(8),
-                    color: Colors.grey.shade300,
+                    color: Colors.grey.shade800,
                   ),
-                  child: const Icon(Icons.add),
+                  child: const Icon(Icons.add, color: Colors.white),
                 ),
               ),
             );

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,5 +9,9 @@ void main() {
 
     expect(find.text('Add Videos'), findsOneWidget);
     expect(find.byIcon(Icons.video_library), findsOneWidget);
+    expect(find.byIcon(Icons.delete_forever), findsOneWidget);
+    final deleteButton =
+        tester.widget<IconButton>(find.byIcon(Icons.delete_forever));
+    expect(deleteButton.onPressed, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- extract reusable EditorAppBar with back button and action icons
- apply darker CapCut-inspired theme and outlined add button
- restyle timeline and toolbar for CapCut-like appearance

## Testing
- `dart format lib/main.dart lib/pages/multi_video_editor_page.dart lib/widgets/editor_app_bar.dart lib/widgets/video_track.dart lib/widgets/timeline_clip.dart lib/widgets/editor_toolbar.dart` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68af25b703588326b78ae150927b3562