### PR TITLE
feat: capcut-inspired theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,11 +13,19 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Simple Video Editor',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.teal,
-          brightness: Brightness.dark,
+        brightness: Brightness.dark,
+        scaffoldBackgroundColor: const Color(0xFF0F0F0F),
+        colorScheme: const ColorScheme.dark(
+          primary: Color(0xFF21CFF3),
+          secondary: Color(0xFF21CFF3),
+          background: Color(0xFF0F0F0F),
+          surface: Color(0xFF161616),
         ),
-        scaffoldBackgroundColor: Colors.black,
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Color(0xFF0F0F0F),
+          elevation: 0,
+        ),
+        iconTheme: const IconThemeData(color: Colors.white),
         useMaterial3: true,
       ),
       home: const MultiVideoEditorPage(),

--- a/lib/widgets/editor_toolbar.dart
+++ b/lib/widgets/editor_toolbar.dart
@@ -31,7 +31,11 @@ class EditorToolbar extends StatelessWidget {
               const SizedBox(height: 4),
               Text(
                 label,
-                style: const TextStyle(color: Colors.white, fontSize: 12),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ],
           ),
@@ -43,7 +47,12 @@ class EditorToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Colors.black87,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: const Border(
+          top: BorderSide(color: Colors.white24),
+        ),
+      ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: [

--- a/lib/widgets/timeline_clip.dart
+++ b/lib/widgets/timeline_clip.dart
@@ -28,7 +28,9 @@ class TimelineClip extends StatelessWidget {
       margin: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         border: Border.all(
-          color: selected ? Colors.teal : Colors.transparent,
+          color: selected
+              ? Theme.of(context).colorScheme.primary
+              : Colors.transparent,
           width: 3,
         ),
         borderRadius: BorderRadius.circular(8),

--- a/lib/widgets/video_track.dart
+++ b/lib/widgets/video_track.dart
@@ -73,9 +73,9 @@ class VideoTrack extends StatelessWidget {
                   margin: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(8),
-                    color: Colors.grey.shade300,
+                    color: const Color(0xFF2A2A2A),
                   ),
-                  child: const Icon(Icons.add),
+                  child: const Icon(Icons.add, color: Colors.white),
                 ),
               ),
             );


### PR DESCRIPTION
## Summary
- adopt dark CapCut-inspired color scheme and app bar
- style toolbar, timeline clips, and add button to match CapCut aesthetics

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00fe7f45883268f73f2f41735fa79